### PR TITLE
modified dockerfile in multi-stage mode to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE=intersystemsdc/irishealth-community
 ARG IMAGE=intersystemsdc/iris-community:preview
 ARG IMAGE=intersystemsdc/iris-community
-FROM $IMAGE
+FROM $IMAGE as builder
 
 WORKDIR /home/irisowner/dev
 
@@ -24,3 +24,11 @@ RUN --mount=type=bind,src=.,dst=. \
     iris merge IRIS merge.cpf && \
     irispython iris_script.py && \
     iris stop IRIS quietly
+
+FROM $IMAGE as final
+
+ADD --chown=${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} https://github.com/grongierisc/iris-docker-multi-stage-script/releases/latest/download/copy-data.py /irisdev/app/copy-data.py
+
+RUN --mount=type=bind,source=/,target=/builder/root,from=builder \
+    cp -f /builder/root/usr/irissys/iris.cpf /usr/irissys/iris.cpf && \
+    python3 /irisdev/app/copy-data.py -c /usr/irissys/iris.cpf -d /builder/root/ 

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="iris-python-template.ZPM">
     <Module>
       <Name>iris-python-template</Name>
-      <Version>3.0.3</Version>
+      <Version>3.0.4</Version>
       <Description>The simplest template to run embedded python</Description>
       <Packaging>module</Packaging>
       <SourcesRoot>src</SourcesRoot>

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="iris-python-template.ZPM">
     <Module>
       <Name>iris-python-template</Name>
-      <Version>3.0.4</Version>
+      <Version>3.0.5</Version>
       <Description>The simplest template to run embedded python</Description>
       <Packaging>module</Packaging>
       <SourcesRoot>src</SourcesRoot>

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="iris-python-template.ZPM">
     <Module>
       <Name>iris-python-template</Name>
-      <Version>3.0.5</Version>
+      <Version>3.0.6</Version>
       <Description>The simplest template to run embedded python</Description>
       <Packaging>module</Packaging>
       <SourcesRoot>src</SourcesRoot>


### PR DESCRIPTION
before
iris-embedded-python-template-iris-1   804MB (virtual 4.04GB)
after
iris-embedded-python-template-iris-1   803MB (virtual 3.38GB)
