### PR TITLE
FIX: added fixes to argument syntax, readme correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Follow it - it will let to execute Embedded Python scripts vs IRIS and develop i
 
 Once devcontainer is opened go to /python/irisapp.py and run it, either with Run button in the top right corner, or in terminal via:
 ```bash
-$ irispython /python/irisapp.py
+$ irispython python/irisapp.py
 ```
 
 
@@ -222,7 +222,7 @@ $ docker-compose exec iris bash
 
 Run the following commands to start the flask server:
 ```
-irispython /python/flask/app.py
+irispython python/flask/app.py
 ```
 
 That will start the flask server and you will see the following output:

--- a/src/dc/python/PersistentClass.cls
+++ b/src/dc/python/PersistentClass.cls
@@ -4,7 +4,7 @@ Class dc.python.PersistentClass Extends %Persistent
 /// Description
 Property Test As %VarString;
 
-ClassMethod CreateRecord(propValue As %VarString = "TestString", ByRef id As %Integer) As %Status
+ClassMethod CreateRecord(propValue As %VarString = "TestString", id As %Integer) As %Status
 {
     set sc=$$$OK
     set obj=..%New()
@@ -14,7 +14,7 @@ ClassMethod CreateRecord(propValue As %VarString = "TestString", ByRef id As %In
     return sc
 }
 
-ClassMethod CreateRecordPython(propValue As %VarString, ByRef id As %Integer) [ Language = python ]
+ClassMethod CreateRecordPython(propValue As %VarString, id As %Integer) [ Language = python ]
 {
     import iris
     obj=iris.cls(__name__)._New()


### PR DESCRIPTION
1. ByRef is not accepted by python through the arguments

2. There is a problem calling script like this `irispython /path/to/file.py`
Calling it `irispython path/to/file.py` works well

(in the report i suggest to go to the destination first. but you can call the script just without forward slash)